### PR TITLE
Remove bors.toml.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,0 @@
-status = [
-  "Lint",
-  "Test",
-]
-
-delete_merged_branches = true


### PR DESCRIPTION
The public Bors instance is deprecated in favor of GitHub Merge Queues, so I'm migrating Tinker to use Merge Queues.